### PR TITLE
[dejagnu] Add inspec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# dejagnu
+
+A framework for testing other programs.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.dejagnu?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # dejagnu
 
 A framework for testing other programs.

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,1 +1,1 @@
-command_relative_path: '/bin/runtest'
+command_relative_path: 'bin/runtest'

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+command_relative_path: '/bin/runtest'

--- a/controls/dejagnu_exists.rb
+++ b/controls/dejagnu_exists.rb
@@ -7,7 +7,8 @@ control 'core-plans-dejagnu-exists' do
   impact 1.0
   title 'Ensure dejagnu exists'
   desc '
-  '
+  Verify dejagnu by ensuring /bin/runtest exists'
+  
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }

--- a/controls/dejagnu_exists.rb
+++ b/controls/dejagnu_exists.rb
@@ -13,6 +13,7 @@ control 'core-plans-dejagnu-exists' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
   end
 
   command_relative_path = input('command_relative_path', value: 'bin/runtest')

--- a/controls/dejagnu_exists.rb
+++ b/controls/dejagnu_exists.rb
@@ -1,0 +1,22 @@
+title 'Tests to confirm dejagnu exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'dejagnu')
+ 
+control 'core-plans-dejagnu-exists' do
+  impact 1.0
+  title 'Ensure dejagnu exists'
+  desc '
+  '
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  command_relative_path = input('command_relative_path', value: '/bin/runtest')
+  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+  describe file(command_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/dejagnu_exists.rb
+++ b/controls/dejagnu_exists.rb
@@ -2,12 +2,12 @@ title 'Tests to confirm dejagnu exists'
 
 plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'dejagnu')
- 
+
 control 'core-plans-dejagnu-exists' do
   impact 1.0
   title 'Ensure dejagnu exists'
   desc '
-  Verify dejagnu by ensuring /bin/runtest exists'
+  Verify dejagnu by ensuring bin/runtest exists'
   
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
@@ -15,8 +15,8 @@ control 'core-plans-dejagnu-exists' do
     its('stdout') { should_not be_empty }
   end
 
-  command_relative_path = input('command_relative_path', value: '/bin/runtest')
-  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+  command_relative_path = input('command_relative_path', value: 'bin/runtest')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
   describe file(command_full_path) do
     it { should exist }
   end

--- a/controls/dejagnu_works.rb
+++ b/controls/dejagnu_works.rb
@@ -1,0 +1,27 @@
+title 'Tests to confirm dejagnu works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'dejagnu')
+
+control 'core-plans-dejagnu-works' do
+  impact 1.0
+  title 'Ensure dejagnu works as expected'
+  desc '
+  Note: although the stderr contains a WARNING, the stdout contains the required 
+  version information so this test achieves its aim of detecting the dejagnu version
+  '
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
+  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} runtest --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /DejaGnu version\s+#{plan_pkg_version}/ }
+    its('stderr') { should match /WARNING: Couldn't find the global config file/ }
+  end
+end

--- a/controls/dejagnu_works.rb
+++ b/controls/dejagnu_works.rb
@@ -16,6 +16,7 @@ control 'core-plans-dejagnu-works' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
   end
   
   command_relative_path = input('command_relative_path', value: 'bin/runtest')

--- a/controls/dejagnu_works.rb
+++ b/controls/dejagnu_works.rb
@@ -7,8 +7,9 @@ control 'core-plans-dejagnu-works' do
   impact 1.0
   title 'Ensure dejagnu works as expected'
   desc '
-  Verify dejagnu by ensuring (1) its installation directory exists and (2) that
-  it returns the expected version
+  Verify dejagnu by ensuring 
+  (1) its installation directory exists and 
+  (2) that it returns the expected version.
   '
   
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
@@ -17,9 +18,10 @@ control 'core-plans-dejagnu-works' do
     its('stdout') { should_not be_empty }
   end
   
-  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
-  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
-  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} runtest --version") do
+  command_relative_path = input('command_relative_path', value: 'bin/runtest')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
+  plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
+  describe command("#{command_full_path} --version") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
     its('stdout') { should match /DejaGnu version\s+#{plan_pkg_version}/ }

--- a/controls/dejagnu_works.rb
+++ b/controls/dejagnu_works.rb
@@ -7,9 +7,10 @@ control 'core-plans-dejagnu-works' do
   impact 1.0
   title 'Ensure dejagnu works as expected'
   desc '
-  Note: although the stderr contains a WARNING, the stdout contains the required 
-  version information so this test achieves its aim of detecting the dejagnu version
+  Verify dejagnu by ensuring (1) its installation directory exists and (2) that
+  it returns the expected version
   '
+  
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: dejagnu
+title: Habitat Core Plan dejagnu
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan dejagnu
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,55 @@
+pkg_name=dejagnu
+pkg_origin=core
+pkg_version=1.6.2
+pkg_license=('GPL-3.0-or-later')
+pkg_upstream_url="https://www.gnu.org/software/dejagnu/"
+pkg_description="A framework for testing other programs."
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="https://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum="0d0671e1b45189c5fc8ade4b3b01635fb9eeab45cf54f57db23e4c4c1a17d261"
+pkg_deps=(
+  core/expect
+  core/coreutils
+  core/sed
+  core/grep
+)
+pkg_build_deps=(
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+
+do_check() {
+  make check
+}
+
+do_install() {
+  do_default_install
+
+  # Set an absolute path `expect` in the `runtest` binary
+  sed \
+    -e "s,expectbin=expect,expectbin=$(pkg_path_for expect)/bin/expect,g" \
+    -i "$pkg_prefix/bin/runtest"
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+    core/coreutils
+    core/sed
+    core/diffutils
+    core/make
+    core/patch
+  )
+fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,6 @@
+@test "Dejagnu runtest isn't missing dependencies" {
+  # This exercices the cli to determine if there are any
+  # missing dependencies, such as `sed` or `expr`
+  run /bin/hab pkg exec $pkg_ident runtest --help
+  [ "$status" -eq 0 ]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+if [[ -z "${1:-}" ]]; then
+  echo "Usage: test.sh <fully qualified package ident>"
+  echo
+  echo "ex: test.sh core/dejagnu/1.6.1/20181108171344"
+  exit 1
+fi
+
+pkg_ident=${1}
+# This depends on the package being present on the depot OR
+# in your local cache. If you're testing locally this is a
+# reasonably safe assumption to make, as long as the cache
+# isn't cleaned aggressively
+hab pkg install "$pkg_ident"
+hab pkg install core/bats
+
+# Execute the following in a subshell so that our exports
+# don't pollute the studio environment
+(
+  export pkg_ident
+  hab pkg exec core/bats bats "$(dirname "$0")"/test.bats
+)


### PR DESCRIPTION
### Outstanding tasks:
- [x] remove DEBUG
- [x] use full path to binary instead of hab pkg exec
- [x] parsing the pkg_version from the installation path.

```rspec
hab pkg exec chef/inspec inspec exec /src/. --chef-license=accept -t docker://b63f9b13fc12b5c46e6df13215bb4a27485f48dc79e740e0583f3da5d797dd6a --input-file /src/attributes.yml

Profile: Habitat Core Plan dejagnu (dejagnu)
Version: 0.1.0
Target:  docker://b63f9b13fc12b5c46e6df13215bb4a27485f48dc79e740e0583f3da5d797dd6a

  ✔  core-plans-dejagnu-works: Ensure dejagnu works as expected
     ✔  Command: `hab pkg path core/dejagnu` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/dejagnu` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/dejagnu/1.6.2/20200603150736 runtest --version` exit_status is expected to eq 0
     ✔  Command: `DEBUG=true; hab pkg exec core/dejagnu/1.6.2/20200603150736 runtest --version` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/dejagnu/1.6.2/20200603150736 runtest --version` stdout is expected to match /DejaGnu\s+version\s+(1.6.2)/
     ✔  Command: `DEBUG=true; hab pkg exec core/dejagnu/1.6.2/20200603150736 runtest --version` stderr is expected to match /WARNING: Couldn't find the global config file/
  ✔  core-plans-dejagnu-exists: Ensure dejagnu exists
     ✔  File /hab/pkgs/core/dejagnu/1.6.2/20200603150736/bin/runtest is expected to exist


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 7 successful, 0 failures, 0 skipped
+ set +x
[12][default:/src:0]# 
```